### PR TITLE
ci(deps): bump actions/checkout from 4 to 5 in the github-actions group

### DIFF
--- a/.github/workflows/json-lint.yml
+++ b/.github/workflows/json-lint.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       # 1. Checkout Repository with Full History
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           sparse-checkout-cone-mode: false


### PR DESCRIPTION
Bumps the github-actions group with 1 update: [actions/checkout](https://github.com/actions/checkout).


Updates `actions/checkout` from 4 to 5
- [Release notes](https://github.com/actions/checkout/releases)
- [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- [Commits](https://github.com/actions/checkout/compare/v4...v5)

---
updated-dependencies:
- dependency-name: actions/checkout dependency-version: '5' dependency-type: direct:production update-type: version-update:semver-major dependency-group: github-actions ...

# Pull Request

## Summary

<!-- Provide a brief description of your changes -->

## Issue

<!-- Link to the issue this PR closes, or describe the context if no issue -->

## Checklist

- [ ] I ran `yarn format` on all modified files
- [ ] `yarn prettier --check .` succeeds
- [ ] Documentation updated if necessary
